### PR TITLE
split build-docker build into newinstall & build

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ In theory, these images can both be uploaded to aws and openstack/nebula.
 from bento repos on the `builder/aws` branch
 
 (source AMI credentials in env)
-./bin/packer build --only=qemu --var headless=true centos-7.1-x86_64.json
-./bin/packer build --only=qemu --var headless=true centos-6.7-x86_64.json
+
+    ./bin/packer build --only=qemu --var headless=true centos-7.1-x86_64.json
+    ./bin/packer build --only=qemu --var headless=true centos-6.7-x86_64.json
 
 Upload a QEMU/KVM image to EC2 as the image of a shutdown instance
 ---
@@ -132,10 +133,12 @@ After the upload/import completes, the instance can be converted to an ami.
 
 See: https://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ApiReference-cmd-ImportInstance.html
 
-Note that the destination instance type is restricted.  See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/VMImportTroubleshooting.html#LinuxNotSupported
+Note that the destination instance type is restricted.  See:
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/VMImportTroubleshooting.html#LinuxNotSupported
 
 (build kvm images with packer/bento)
 
+```
 wget http://s3.amazonaws.com/ec2-downloads/ec2-api-tools.zip
 unzip ec2-api-tools.zip
 export EC2_HOME=`pwd`/ec2-api-tools-1.7.5.1
@@ -203,6 +206,7 @@ final "product"
 aws ec2 modify-image-attribute --image-id $IMAGE_ID --launch-permission "{\"Add\":[{\"Group\":\"all\"}]}"
 
 aws ec2 describe-image-attribute --image-id $IMAGE_ID --attribute launchPermission
+```
 
 
 Upload a QEMU/KVM image directly as a volume
@@ -210,13 +214,13 @@ Upload a QEMU/KVM image directly as a volume
 
 See: https://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ApiReference-cmd-ImportVolume.html
 
-qemu-img convert -f qcow2 -O raw packer-centos-6.7-x86_64-qemu/centos-6.7-x86_64 packer-centos-6.7-x86_64-qemu/centos-6.7-x86_64.raw
+    qemu-img convert -f qcow2 -O raw packer-centos-6.7-x86_64-qemu/centos-6.7-x86_64 packer-centos-6.7-x86_64-qemu/centos-6.7-x86_64.raw
 
-./ec2-api-tools-1.7.5.1/bin/ec2-import-volume packer-centos-6.7-x86_64-qemu/centos-6.7-x8 bucketmantakemetoouterspace --owner-akid $AWS_ACCESS_KEY_ID --owner-sak $AWS_SECRET_ACCESS_KEY --region us-east-1
+    ./ec2-api-tools-1.7.5.1/bin/ec2-import-volume packer-centos-6.7-x86_64-qemu/centos-6.7-x8 bucketmantakemetoouterspace --owner-akid $AWS_ACCESS_KEY_ID --owner-sak $AWS_SECRET_ACCESS_KEY --region us-east-1
 
-./ec2-api-tools-1.7.5.1/bin/ec2-describe-conversion-tasks
+    ./ec2-api-tools-1.7.5.1/bin/ec2-describe-conversion-tasks
 
-# find VolumeId in output. Eg.
-# VolumeId vol-5d2785be
+    # find VolumeId in output. Eg.
+    # VolumeId vol-5d2785be
 
 **A volume has to be attached to an instance before it can be converted to an AMI (why?????)**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ bootstrap process with the individual packages built from `eups distrib`.  The
 intent is to closely replicate the process a down-stream consumer of LSST DM
 software products would use.
 
-Openstack/Nebula Images
+OpenStack/Nebula Images
 ---
 
 __At present, Nebula images are based on "published" Centos 6/7 images provided
@@ -25,7 +25,8 @@ Source the `LSST-openrc.sh` step script so that the env vars necessary for
 
 ### Step 1
 
-Build base images suitable for usage by vagrant with jhoblitt's fork of `bento`.
+Build base images suitable for usage by vagrant with jhoblitt's fork of
+`bento`.
 
     git clone git@github.com:jhoblitt/bento.git -b builder/aws
     cd bento
@@ -34,18 +35,29 @@ Build base images suitable for usage by vagrant with jhoblitt's fork of `bento`.
     ./packer/packer build --only=openstack ./centos-6.7-x86_64.json
     ./packer/packer build --only=openstack ./centos-7.2-x86_64.json
 
+_The `bento` images only need to be [re-]recreated upon new features or major
+base OS changes.  Such as a new minor release._
+
 ### Step 2
 
 Build `newinstall` base images that have all operating system prerequisites
-installed along with the basic `newinstall.sh` prepared build env.
+installed along with the basic `newinstall.sh` prepared build env.  Here the
+`CENTOSX_IMAGE` env vars should be set to the UUID ID of the current `bento`
+base images.
 
     export CENTOS6_IMAGE=<...>
     export CENTOS7_IMAGE=<...>
     ./build-openstack newinstall
 
+_The `newinstall` images should be created when ever changes (directly or
+indirectly) occur to `newinstall.sh` or when new `bento` images have been
+generated._
+
 ### Step 3
 
-Build the end-user consumable `stack` images with pre-build eups products.
+Build the end-user consumable `stack` images with pre-build eups products.  The
+`CENTOSX_IMAGE` env bars need to be updated to the UUID of the `newinstall`
+generated images.
 
     export TAG=w_2016_05
     export PRODUCTS=lsst_distrib
@@ -59,6 +71,10 @@ Run the stack demo on an instance created from each new candidate image.
 
 See: http://sqr-002.lsst.io/en/latest/#running-the-stack-demo
 
+This may be conveniently accomplished by cloning the
+https://github.com/lsst-sqre/vagrant-nebula.git repo and updating the UUIDs for
+the `el6` and `el7` boxes.
+
 ### Step 5
 
 Update these repos:
@@ -66,41 +82,58 @@ Update these repos:
 * https://github.com/lsst-sqre/sqr-002
 * https://github.com/lsst-sqre/vagrant-nebula
 
-Then announce it to the [LSST DM] world.
+Then announce it to the [LSST DM] world via `community.lsst.org` and on the
+hipchat `square` and `nebula` channels.
+
 
 Docker containers
 ---
 
+### Step 0
+
+Log into a dockerhub account that is a member of the `lsstsqre` organization.
+
+    docker login
+    ....
+
 ### Step 1
+
+Build the intermediate `newinstall` images.
+
+    ./build-docker newinstall
+
+_The `newinstall` images should be created when ever changes (directly or
+indirectly) occur to `newinstall.sh` or when new `bento` images have been
+generated._
+
+### Step 2
+
+Build the `stack` consumable images.
 
     export TAG=w_2016_05
     export PRODUCTS=lsst_distrib
     ./build-docker build
 
-### Step 2
-
-Must be logged into a dockerhub account that can push to `lsstsqre`.
-
-    docker login
-    ....
+### Step 3
 
 Push final container images
 
     ./build-docker push
 
-### Step 3
+### Step 4
 
-Run the stack demo on an instance created from each new candidate image.
+Run the stack demo on a container created from each new candidate image.
 
 See: http://sqr-002.lsst.io/en/latest/#running-the-stack-demo
 
-### Step 4
+### Step 5
 
 Update these repos:
 
 * https://github.com/lsst-sqre/sqr-002
 
-Then announce it to the [LSST DM] world.
+Then announce it to the [LSST DM] world via `community.lsst.org` and on the
+hipchat `square` channel.
 
 
 Work-in-progress QEMU->Nebula upload instructions

--- a/build-docker
+++ b/build-docker
@@ -33,7 +33,7 @@ if [[ $# -gt 1 ]]; then
 fi
 
 case $1 in
-    build | push)
+    newinstall | build | push)
         STEP=$1
         ;;
     *)
@@ -45,13 +45,19 @@ echo "building step: $STEP"
 
 
 case $STEP in
-    build)
+    newinstall)
         make
         bundle install
         bundle exec librarian-puppet install
 
         ./bin/packer build --only=docker-centos-6,docker-centos-7 centos_packerprep.json
         ./bin/packer build --only=docker-centos-6,docker-centos-7 centos_newinstall.json
+        ;;
+    build)
+        make
+        bundle install
+        bundle exec librarian-puppet install
+
         ./bin/packer build --only=docker-centos-6,docker-centos-7 -var tag="$TAG" -var products="$PRODUCTS" centos_build.json
 
         # packer can't set the USER or WORKDIR on a container so we are using trivial


### PR DESCRIPTION
The monolithic `build` step is convenient for automation but resulted in
new intermediate containers being generated for every build.  A single
integrated step was relatively performant but resulted in the end user
have to re-download multiple layers instead of [potentially] only the the
most recent build.  The intermediate 'newinstall' containers will still
need to be periodically updated.
